### PR TITLE
Fix README.md to reflect actual package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# texinfo
-Texinfo is the official documentation format of the GNU project.
+# wget
+GNU Wget is a free software package for retrieving files using HTTP, HTTPS, FTP and FTPS, the most widely used Internet protocols.


### PR DESCRIPTION
The README.md uses the information from the texinfo README.md meaning that any attempt to use the information in the md file within the shipped pax results in incorrect output